### PR TITLE
Reduce eslint update frequency

### DIFF
--- a/js.json
+++ b/js.json
@@ -39,7 +39,10 @@
         },
         {
             "matchPackagePatterns": ["eslint"],
-            "groupName": "eslint"
+            "groupName": "eslint",
+            "schedule": [
+                "before 4am on the first day of the month"
+            ],
         },
         {
             "matchPackagePatterns": ["relay"],
@@ -58,6 +61,7 @@
             "groupName": "OpenTelemetry"
         }
     ],
+    "timezone": "UTC",
     "schedule": [
         "before 4am every weekday"
     ],


### PR DESCRIPTION
Eslint and its related libraries are just tooling, and some of the libraries from their ecosystem (`@typescript-eslint/parser`) update multiple times per week, generating multiple PRs that are essentially noise.

This PR is to batch such updates to happen once a month instead of every day.