### PR TITLE
Add npm ci to downstream validation jobs

### DIFF
--- a/.github/workflows/javascript-validations.yml
+++ b/.github/workflows/javascript-validations.yml
@@ -89,6 +89,9 @@ jobs:
           node-version: ${{ inputs.node-version }}
           cache: 'npm'
 
+      - name: Install dependencies
+        run: npm ci
+
       - name: Lint
         env:
           NODE_OPTIONS: --max-old-space-size=7168
@@ -104,6 +107,9 @@ jobs:
         with:
           node-version: ${{ inputs.node-version }}
           cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
 
       - name: Validate
         run: ${{ inputs.validate-command }}
@@ -122,6 +128,9 @@ jobs:
         with:
           node-version: ${{ inputs.node-version }}
           cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
 
       - name: Run tests
         env:
@@ -146,6 +155,9 @@ jobs:
         with:
           node-version: ${{ inputs.node-version }}
           cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
 
       - name: Audit dependencies
         run: |


### PR DESCRIPTION
## Summary

The `setup` job runs `npm ci` to install dependencies, but each downstream job (`code-style`, `static-analysis`, `unit-tests`, `vulnerabilities`) runs in its own isolated workspace. The `actions/setup-node` with `cache: 'npm'` restores the npm download cache (`~/.npm`), which makes `npm ci` fast — but it still needs to run to populate `node_modules`.

Without this, downstream jobs fail with errors like:
- `sh: 1: eslint: not found`
- `Cannot find type definition file for 'jest'`

This adds `npm ci` to each downstream job after restoring the npm cache.

## Test plan
- [ ] Verify `plug-vue` CI passes after this merges
- [ ] Verify `plug-react` lint job passes after this merges